### PR TITLE
move constants out of shared folder

### DIFF
--- a/packages/components/src/Loc.js
+++ b/packages/components/src/Loc.js
@@ -1,5 +1,5 @@
 import { makeLocalizedElement } from './make-localized-element';
-import { STANDARD_ELEMENT_TYPES } from '../../../shared/constants';
+import { STANDARD_ELEMENT_TYPES } from './constants';
 
 export const Loc = {
   A: makeLocalizedElement('a'),

--- a/packages/components/src/constants.js
+++ b/packages/components/src/constants.js
@@ -1,19 +1,4 @@
-const AST_NODE_TYPES = {
-  JSXElement: 'JSXElement',
-  JSXText: 'JSXText',
-  JSXExpressionContainer: 'JSXExpressionContainer',
-  JSXEmptyExpression: 'JSXEmptyExpression',
-  StringLiteral: 'StringLiteral'
-};
-
-const FLUENT_ATTRS = {
-  attrs: 'attrs',
-  l10nId: 'l10nId',
-  l10nVars: 'l10nVars',
-  l10nJSX: 'l10nJSX'
-};
-
-const STANDARD_ELEMENT_TYPES = {
+export const STANDARD_ELEMENT_TYPES = {
   A: {},
   Abbr: {},
   Address: {},
@@ -89,9 +74,3 @@ const STANDARD_ELEMENT_TYPES = {
   Var: {},
   Video: {}
 };
-
-module.exports = {
-  STANDARD_ELEMENT_TYPES,
-  FLUENT_ATTRS,
-  AST_NODE_TYPES
-}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -1,3 +1,4 @@
 export * from './Loc';
 export * from './make-localized-element';
 export * from './pseudolocalize';
+export * from './constants';

--- a/packages/extraction/package.json
+++ b/packages/extraction/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@babel/parser": "^7.1.0",
     "babylon-walk": "^1.0.2",
+    "fluent-react-components": "*",
     "fluent-syntax": "^0.8.1",
     "glob": "^7.1.3",
     "jsx-ast-utils": "^2.0.1",

--- a/packages/extraction/src/ast-helper.js
+++ b/packages/extraction/src/ast-helper.js
@@ -1,5 +1,6 @@
+import { STANDARD_ELEMENT_TYPES } from 'fluent-react-components';
 import { getProp, elementType as _elementType, hasProp } from 'jsx-ast-utils';
-import { AST_NODE_TYPES, FLUENT_ATTRS, STANDARD_ELEMENT_TYPES } from '../../../shared/constants';
+import { AST_NODE_TYPES, FLUENT_ATTRS } from './constants';
 import { defaultShorthandName } from './defaults';
 import { formatRule, pullLocalizedDOMAttributes, formatMessage } from './format-helper';
 

--- a/packages/extraction/src/constants.js
+++ b/packages/extraction/src/constants.js
@@ -1,0 +1,14 @@
+export const AST_NODE_TYPES = {
+  JSXElement: 'JSXElement',
+  JSXText: 'JSXText',
+  JSXExpressionContainer: 'JSXExpressionContainer',
+  JSXEmptyExpression: 'JSXEmptyExpression',
+  StringLiteral: 'StringLiteral'
+};
+
+export const FLUENT_ATTRS = {
+  attrs: 'attrs',
+  l10nId: 'l10nId',
+  l10nVars: 'l10nVars',
+  l10nJSX: 'l10nJSX'
+};


### PR DESCRIPTION
resolves error `Module not found: Error: Can't resolve '../../../shared/constants' in '/Users/heidi/projects/udacity/emc-web/node_modules/fluent-react-components/lib'`